### PR TITLE
Fixed outdated youtube_dlp with yt-dlp

### DIFF
--- a/download_voxCeleb.py
+++ b/download_voxCeleb.py
@@ -13,7 +13,7 @@ from skimage import img_as_ubyte
 from skimage.transform import resize
 warnings.filterwarnings("ignore")
 import cv2
-import youtube_dl
+import yt_dlp as youtube_dl	# Changed import
 import subprocess
 
 from libs.utilities import make_path

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ tqdm
 matplotlib 
 scipy>=0.17.0
 numba
+yt-dlp


### PR DESCRIPTION
Hi,

Thanks for the preprocessing codes, they are super useful!

But, I noticed that `youtube_dl` was outdated and caused "ERROR: Unable to extract uploader id; ...". 
I tried `pip install --upgrade youtube_dl`, and it lead to the same error. The umbrella library `yt-dlp` fixes this. 

I have modified
- `download_voxCeleb.py` to incorporate this change in library import
- `requirements.txt` to reflect the need to import `yt-dlp` library

I have tested it and it runs perfectly alright now. I'd apprecitate it if you guys took a look! Thanks :)